### PR TITLE
add etymology entries to definitions

### DIFF
--- a/3-tidy-up.js
+++ b/3-tidy-up.js
@@ -214,9 +214,7 @@ function handleLine(parsedLine) {
             const breakdown = breakdownEtymology(etymology_text);
 
             if (
-                targetIso === 'en' &&
-                breakdown &&
-                breakdown !== etymology_text
+                targetIso === 'en' && breakdown
             ) {
                 lemmaDict[word][reading][pos][etymology_number].breakdown_text = breakdown;
             }
@@ -253,7 +251,6 @@ function breakdownEtymology(text) {
     for (const part of text.split(/;|\.|\*/g).map(item => item.trim())) {
         if (part.includes(' + ') && !part.includes('Proto')) {
             return part
-            .replace(/ \([^“"].+?\)+/g, '')
             .replace('By surface analysis, ', '')
         }
     }

--- a/data/styles.css
+++ b/data/styles.css
@@ -1,7 +1,8 @@
 div[data-sc-content="extra-info"] {
     margin-left: 0.5em;
 }
-div[data-sc-content="example-sentence"] {
+div[data-sc-content="example-sentence"],
+div[data-sc-content="etymology-entry"] {
     background-color: color-mix(in srgb, var(--text-color, var(--fg, #333)) 5%, transparent);
     border-color: var(--text-color, var(--fg, #333));
     border-style: none none none solid;
@@ -15,6 +16,12 @@ div[data-sc-content="example-sentence-a"] {
     font-size: 1.1em;
     font-style: italic;
 }
-div[data-sc-content="example-sentence-b"] {
+div[data-sc-content="example-sentence-b"],
+div[data-sc-content="etymology-entry"] {
     font-size: 0.8em;
+}
+div[data-sc-content="etymology-entry"] {
+    opacity: 0.8;
+    border-color: #c1c1c1;
+    display: none;
 }

--- a/data/test/dict/cs/en/term_bank_1.json
+++ b/data/test/dict/cs/en/term_bank_1.json
@@ -137,6 +137,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Deverbal from zpravit."
+            }
           }
         ]
       }
@@ -187,6 +200,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Old Czech pro, from Proto-Slavic *pro."
+            }
           }
         ]
       }
@@ -209,6 +235,19 @@
             "content": [
               "(reflexive with se) to dispute"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Old Czech přieti, from Proto-Slavic *pьrěti."
+            }
           }
         ]
       }

--- a/data/test/dict/de/de/term_bank_1.json
+++ b/data/test/dict/de/de/term_bank_1.json
@@ -42,6 +42,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 von arabisch/persisch ruh, roh entlehnt, = arabisch: الرُخّ (ar-ruchch, aus dem Persischen)"
+            }
           }
         ]
       }
@@ -259,6 +272,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 seit dem 20. Jahrhundert bezeugte Entlehnung aus gleichbedeutendem französisch garage ^(→ fr) m, eigentlich „(das) Ausweichen, Ausweichstelle“; dieses ist eine deverbative Ableitung von französisch garer ^(→ fr) „in eine sichere Verwahrstelle bringen; in Sicherheit bringen; ausweichen“, das seinerseits aus okzitanisch garar ^(→ oc) „Acht geben, bewahren“ übernommen wurde; dieses entstammt entweder mit Übergang von w- zu g- der (nicht belegbaren, aber rekonstruierten) germanischen Form *war-ō- „beachten“ (vergleiche »wahren«) oder dem lateinischen varāre ^(→ la) „ausweichen“ (zu lateinisch vārus ^(→ la) „auseinandergebogen“)"
+            }
           }
         ]
       }

--- a/data/test/dict/de/en/term_bank_1.json
+++ b/data/test/dict/de/en/term_bank_1.json
@@ -154,6 +154,19 @@
                 ]
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German phlëgen, from Old High German plëgan, from Proto-West Germanic *plehan."
+            }
           }
         ]
       }
@@ -450,6 +463,19 @@
                 ]
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German phlëgen, from Old High German plëgan, from Proto-West Germanic *plehan."
+            }
           }
         ]
       }
@@ -522,6 +548,19 @@
             "content": [
               "a fox in radiosport foxhunt"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German vuhs, from Old High German fuhs, from Proto-West Germanic *fuhs, from Proto-Germanic *fuhsaz, from Proto-Indo-European *púḱsos (“the tailed one”), from *puḱ- (“tail”). Cognate with English fox, Sanskrit पुच्छ (púccha)."
+            }
           }
         ]
       }
@@ -611,6 +650,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German vuhs, from Old High German fuhs, from Proto-West Germanic *fuhs, from Proto-Germanic *fuhsaz, from Proto-Indo-European *púḱsos (“the tailed one”), from *puḱ- (“tail”). Cognate with English fox, Sanskrit पुच्छ (púccha)."
+            }
           }
         ]
       }
@@ -633,6 +685,19 @@
             "content": [
               "A new recruit."
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German vuhs, from Old High German fuhs, from Proto-West Germanic *fuhs, from Proto-Germanic *fuhsaz, from Proto-Indo-European *púḱsos (“the tailed one”), from *puḱ- (“tail”). Cognate with English fox, Sanskrit पुच्छ (púccha)."
+            }
           }
         ]
       }
@@ -683,6 +748,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German vuhs, from Old High German fuhs, from Proto-West Germanic *fuhs, from Proto-Germanic *fuhsaz, from Proto-Indo-European *púḱsos (“the tailed one”), from *puḱ- (“tail”). Cognate with English fox, Sanskrit पुच्छ (púccha)."
+            }
           }
         ]
       }
@@ -705,6 +783,19 @@
             "content": [
               "a tank Transportpanzer Fuchs"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German vuhs, from Old High German fuhs, from Proto-West Germanic *fuhs, from Proto-Germanic *fuhsaz, from Proto-Indo-European *púḱsos (“the tailed one”), from *puḱ- (“tail”). Cognate with English fox, Sanskrit पुच्छ (púccha)."
+            }
           }
         ]
       }
@@ -727,6 +818,19 @@
             "content": [
               "A form of sunscald on hops."
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German vuhs, from Old High German fuhs, from Proto-West Germanic *fuhs, from Proto-Germanic *fuhsaz, from Proto-Indo-European *púḱsos (“the tailed one”), from *puḱ- (“tail”). Cognate with English fox, Sanskrit पुच्छ (púccha)."
+            }
           }
         ]
       }
@@ -749,6 +853,19 @@
             "content": [
               "any gold coin"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German vuhs, from Old High German fuhs, from Proto-West Germanic *fuhs, from Proto-Germanic *fuhsaz, from Proto-Indo-European *púḱsos (“the tailed one”), from *puḱ- (“tail”). Cognate with English fox, Sanskrit पुच्छ (púccha)."
+            }
           }
         ]
       }
@@ -782,6 +899,19 @@
             "content": [
               "sweetheart, darling"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German herze, from Old High German herza, from Proto-West Germanic *hertā, from Proto-Germanic *hertô (“heart”), from Proto-Indo-European *ḱḗr (“heart”).\nCognate with Dutch hart, English heart, Danish hjerte, Gothic 𐌷𐌰𐌹𐍂𐍄𐍉 (hairtō)."
+            }
           }
         ]
       }
@@ -804,6 +934,19 @@
             "content": [
               "hearts"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German herze, from Old High German herza, from Proto-West Germanic *hertā, from Proto-Germanic *hertô (“heart”), from Proto-Indo-European *ḱḗr (“heart”).\nCognate with Dutch hart, English heart, Danish hjerte, Gothic 𐌷𐌰𐌹𐍂𐍄𐍉 (hairtō)."
+            }
           }
         ]
       }
@@ -826,6 +969,34 @@
             "content": [
               "agent noun of fahren; driver (person)"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": [
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "📝 "
+                },
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "fahren (“to drive”) + -er"
+                }
+              ]
+            }
           }
         ]
       }
@@ -1116,6 +1287,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German von (“from”), from Old High German fon, fona (“from”), from Proto-Germanic *afanē, *fanē, *funē (“from”), compound of *afa (from Proto-Indo-European *h₂epó (“from, off”)) + *ana (from Proto-Indo-European *h₂en- (“on”)). Cognate with Old Saxon fana, fan (“from”), Dutch van (“from; of”), Old Frisian fon (“from”)."
+            }
           }
         ]
       }
@@ -1138,6 +1322,19 @@
             "content": [
               "A female cousin."
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German base, from Old High German basa, from Proto-Germanic *baswǭ (“father's sister; paternal aunt”). Compare Saterland Frisian Bääsje (“grandmother”), Dutch baas (“master; boss”). More at boss."
+            }
           }
         ]
       }
@@ -1160,6 +1357,19 @@
             "content": [
               "paternal aunt"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle High German base, from Old High German basa, from Proto-Germanic *baswǭ (“father's sister; paternal aunt”). Compare Saterland Frisian Bääsje (“grandmother”), Dutch baas (“master; boss”). More at boss."
+            }
           }
         ]
       }
@@ -1182,6 +1392,19 @@
             "content": [
               "base (compound that will neutralize an acid)"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 19th c., backformation from Basen, plural of Basis, from Latin basis, from Ancient Greek βάσις (básis)."
+            }
           }
         ]
       }

--- a/data/test/dict/en/en/term_bank_1.json
+++ b/data/test/dict/en/en/term_bank_1.json
@@ -42,6 +42,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle English bryngen, from Old English bringan, from Proto-West Germanic *bringan, from Proto-Germanic *bringaną (“to bring”), from Proto-Indo-European *bʰrenk-, possibly based on *bʰer-.\nCompare West Frisian bringe, Low German bringen, Dutch brengen, German bringen; also Welsh hebrwng (“to bring, lead”), Tocharian B pränk- (“to take away; restrain oneself, hold back”), Latvian brankti (“lying close”), Lithuanian branktas (“whiffletree”)."
+            }
           }
         ]
       }
@@ -92,6 +105,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle English bryngen, from Old English bringan, from Proto-West Germanic *bringan, from Proto-Germanic *bringaną (“to bring”), from Proto-Indo-European *bʰrenk-, possibly based on *bʰer-.\nCompare West Frisian bringe, Low German bringen, Dutch brengen, German bringen; also Welsh hebrwng (“to bring, lead”), Tocharian B pränk- (“to take away; restrain oneself, hold back”), Latvian brankti (“lying close”), Lithuanian branktas (“whiffletree”)."
+            }
           }
         ]
       }
@@ -153,6 +179,19 @@
             "content": [
               "To raise (a lawsuit, charges, etc.) against somebody."
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle English bryngen, from Old English bringan, from Proto-West Germanic *bringan, from Proto-Germanic *bringaną (“to bring”), from Proto-Indo-European *bʰrenk-, possibly based on *bʰer-.\nCompare West Frisian bringe, Low German bringen, Dutch brengen, German bringen; also Welsh hebrwng (“to bring, lead”), Tocharian B pränk- (“to take away; restrain oneself, hold back”), Latvian brankti (“lying close”), Lithuanian branktas (“whiffletree”)."
+            }
           }
         ]
       }
@@ -253,6 +292,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle English bryngen, from Old English bringan, from Proto-West Germanic *bringan, from Proto-Germanic *bringaną (“to bring”), from Proto-Indo-European *bʰrenk-, possibly based on *bʰer-.\nCompare West Frisian bringe, Low German bringen, Dutch brengen, German bringen; also Welsh hebrwng (“to bring, lead”), Tocharian B pränk- (“to take away; restrain oneself, hold back”), Latvian brankti (“lying close”), Lithuanian branktas (“whiffletree”)."
+            }
           }
         ]
       }
@@ -303,6 +355,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle English wayn, from Old English wæġn, from Proto-West Germanic *wagn, from Proto-Germanic *wagnaz, from Proto-Indo-European *woǵʰnos, from *weǵʰ- (“to bring, transport”). Doublet of wagon, borrowed from Middle Dutch.\nCognates\nCognate with West Frisian wein, Dutch wagen, German Wagen, Danish vogn, Norwegian vogn, Swedish vagn. Doublet of wagon, a borrowing from Dutch."
+            }
           }
         ]
       }
@@ -336,6 +401,19 @@
             "content": [
               "(falconry) A female such bird, a male being a tiercel."
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle English faucoun, falcon, faulcon, from Old French falcun, from Late Latin falcō (“falcon”), of Germanic origin, probably via Frankish *falkō (“falcon, hawk”), from Proto-Germanic *falkô (“falcon”), from Proto-Indo-European *pol̑- (“pale”), from *pel- (“fallow”).\ncognates\nCognate with Old English *fealca, fealcen (“falcon”), Dutch valk (“falcon, hawk”), German Falke (“falcon, hawk”), Norwegian and Swedish falk (“falcon”), Icelandic fálki (“falcon”), French faucon (“falcon”), Italian falco (“falcon”), Spanish halcón (“falcon”), Portuguese falcão (“falcon”), Latin falco (“falcon”), Lithuanian pálšas (“pale”), Latvian bāls (“pale”), Latgalian buolgs (“pale”). More at fallow."
+            }
           }
         ]
       }
@@ -358,6 +436,19 @@
             "content": [
               "A light cannon used from the 15th to the 17th century; a falconet."
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Middle English faucoun, falcon, faulcon, from Old French falcun, from Late Latin falcō (“falcon”), of Germanic origin, probably via Frankish *falkō (“falcon, hawk”), from Proto-Germanic *falkô (“falcon”), from Proto-Indo-European *pol̑- (“pale”), from *pel- (“fallow”).\ncognates\nCognate with Old English *fealca, fealcen (“falcon”), Dutch valk (“falcon, hawk”), German Falke (“falcon, hawk”), Norwegian and Swedish falk (“falcon”), Icelandic fálki (“falcon”), French faucon (“falcon”), Italian falco (“falcon”), Spanish halcón (“falcon”), Portuguese falcão (“falcon”), Latin falco (“falcon”), Lithuanian pálšas (“pale”), Latvian bāls (“pale”), Latgalian buolgs (“pale”). More at fallow."
+            }
           }
         ]
       }

--- a/data/test/dict/en/es/term_bank_1.json
+++ b/data/test/dict/en/es/term_bank_1.json
@@ -75,6 +75,19 @@
             "content": [
               "Cachondo, entregado a los placeres."
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Del inglés medio fast, del inglés antiguo fæst."
+            }
           }
         ]
       }

--- a/data/test/dict/es/en/term_bank_1.json
+++ b/data/test/dict/es/en/term_bank_1.json
@@ -120,6 +120,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Old Spanish bivir, viver, vevir, bevir, from Latin vīvere. Compare Ladino bivir, Portuguese viver."
+            }
           }
         ]
       }
@@ -142,6 +155,19 @@
             "content": [
               "to experience, to live through"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Old Spanish bivir, viver, vevir, bevir, from Latin vīvere. Compare Ladino bivir, Portuguese viver."
+            }
           }
         ]
       }

--- a/data/test/dict/fa/en/term_bank_1.json
+++ b/data/test/dict/fa/en/term_bank_1.json
@@ -14,6 +14,19 @@
             "content": [
               "(Khorasan) a kind of pea"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 table\nBorrowed from Hindustani مونگ / मूँग (mūṅg)"
+            }
           }
         ]
       }
@@ -114,6 +127,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Arabic فَارِسِيّ (fārisiyy), from Early New Persian پَارْسِی (pārsī, “Persian, Persic”)."
+            }
           }
         ]
       }

--- a/data/test/dict/fr/en/term_bank_1.json
+++ b/data/test/dict/fr/en/term_bank_1.json
@@ -304,6 +304,19 @@
                 ]
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Middle French prendre, from Old French prendre, prandre, from Latin prēndere, alternative form of prehendere (“to seize”), present active infinitive of prehendō, from prae- (“before”) + *hendō (“to take, seize”) (not attested without prefix), from Proto-Indo-European *gʰed-."
+            }
           }
         ]
       }
@@ -382,6 +395,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Middle French prendre, from Old French prendre, prandre, from Latin prēndere, alternative form of prehendere (“to seize”), present active infinitive of prehendō, from prae- (“before”) + *hendō (“to take, seize”) (not attested without prefix), from Proto-Indo-European *gʰed-."
+            }
           }
         ]
       }
@@ -460,6 +486,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Middle French prendre, from Old French prendre, prandre, from Latin prēndere, alternative form of prehendere (“to seize”), present active infinitive of prehendō, from prae- (“before”) + *hendō (“to take, seize”) (not attested without prefix), from Proto-Indo-European *gʰed-."
+            }
           }
         ]
       }
@@ -538,6 +577,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Middle French prendre, from Old French prendre, prandre, from Latin prēndere, alternative form of prehendere (“to seize”), present active infinitive of prehendō, from prae- (“before”) + *hendō (“to take, seize”) (not attested without prefix), from Proto-Indo-European *gʰed-."
+            }
           }
         ]
       }
@@ -627,6 +679,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Middle French prendre, from Old French prendre, prandre, from Latin prēndere, alternative form of prehendere (“to seize”), present active infinitive of prehendō, from prae- (“before”) + *hendō (“to take, seize”) (not attested without prefix), from Proto-Indo-European *gʰed-."
+            }
           }
         ]
       }
@@ -705,6 +770,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Middle French prendre, from Old French prendre, prandre, from Latin prēndere, alternative form of prehendere (“to seize”), present active infinitive of prehendō, from prae- (“before”) + *hendō (“to take, seize”) (not attested without prefix), from Proto-Indo-European *gʰed-."
+            }
           }
         ]
       }
@@ -727,6 +805,19 @@
             "content": [
               "to seem, to resemble"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Middle French sembler, from Old French sembler, from Late Latin similāre, a verb based on Latin similis (“similar”). Doublet of simuler."
+            }
           }
         ]
       }
@@ -749,6 +840,19 @@
             "content": [
               "to appear"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Middle French sembler, from Old French sembler, from Late Latin similāre, a verb based on Latin similis (“similar”). Doublet of simuler."
+            }
           }
         ]
       }
@@ -800,6 +904,19 @@
                 ]
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Old French chambre, cambre, from Latin cambra, Medieval spelling of Latin camera (“room”), from Ancient Greek καμάρα (kamára, “something with an arched cover: a covered wagon, a covered boat, a vaulted chamber”). Doublet of caméra, a borrowing."
+            }
           }
         ]
       }
@@ -878,6 +995,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Compare Portuguese de acordo."
+            }
           }
         ]
       }

--- a/data/test/dict/ja/en/term_bank_1.json
+++ b/data/test/dict/ja/en/term_bank_1.json
@@ -14,6 +14,48 @@
             "content": [
               "pleasant, delightful, fun, enjoyable"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": [
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "📝 "
+                },
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "normal-text"
+                  },
+                  "content": "⟨tano₁siki₁⟩ → */tanʷosikʲi/ → /tanoshii/\nFrom Old Japanese. First attested in the Kojiki of 712 CE. No Ryukyuan cognates exist; as as result, further derivation unknown. Theories include:\n* "
+                },
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "A compound of 手 (ta, “hand”, combining form) + 伸す (nosu, “to extend”)"
+                },
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "normal-text"
+                  },
+                  "content": "\n*: This is problematic, as nosu has first been attested starting from the early 900s, with no A/B distinction (see Jōdai Tokushu Kanazukai for details).\n* From 田神 (tano, literally “rice paddy god”)\n*: No reading of 神 (*no, “god”) exists.\n* A borrowing from an unknown language\n*: No words resemble *tanV meaning \"fun\" or \"to enjoy\"."
+                }
+              ]
+            }
           }
         ]
       }
@@ -92,6 +134,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 The 連(れん)用(よう)形(けい) (ren'yōkei, “stem or continuative form”) of the verb 好(す)く (suku, “to like, to be fond of, to enjoy, to feel love for”).\nFirst cited to the late 900s in the 宇津保物語 (Utsubo Monogatari)."
+            }
           }
         ]
       }
@@ -142,6 +197,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 According to one theory, derived from 手貫 (tanuki, “arm glove, gauntlet”), which raccoon dog hide was sometimes used for."
+            }
           }
         ]
       }
@@ -192,6 +260,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 According to one theory, derived from 手貫 (tanuki, “arm glove, gauntlet”), which raccoon dog hide was sometimes used for."
+            }
           }
         ]
       }
@@ -214,6 +295,19 @@
             "content": [
               "Short for 狸饂飩 (tanuki-udon) and 狸蕎麦 (tanuki-soba): styles of various noodle dishes"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 According to one theory, derived from 手貫 (tanuki, “arm glove, gauntlet”), which raccoon dog hide was sometimes used for."
+            }
           }
         ]
       }
@@ -264,6 +358,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 According to one theory, derived from 手貫 (tanuki, “arm glove, gauntlet”), which raccoon dog hide was sometimes used for."
+            }
           }
         ]
       }
@@ -286,6 +393,19 @@
             "content": [
               "Short for 狸汁 (tanuki-jiru): a soup made from tanuki meat mixed with daikon, burdock root, etc."
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 According to one theory, derived from 手貫 (tanuki, “arm glove, gauntlet”), which raccoon dog hide was sometimes used for."
+            }
           }
         ]
       }
@@ -847,6 +967,19 @@
             "content": [
               "[I am / someone is] hungry"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 The perfective form of お腹が空く (onaka ga suku, “to become hungry”, literally “one's stomach becomes empty”)."
+            }
           }
         ]
       }

--- a/data/test/dict/ko/en/term_bank_1.json
+++ b/data/test/dict/ko/en/term_bank_1.json
@@ -14,6 +14,19 @@
             "content": [
               "Germany (a country in Europe)"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Sino-Korean word from 獨逸, an orthographic borrowing from Japanese 獨逸 (Doitsu, “Germany”), from Dutch Duits (“German”)."
+            }
           }
         ]
       }

--- a/data/test/dict/la/en/term_bank_1.json
+++ b/data/test/dict/la/en/term_bank_1.json
@@ -159,6 +159,19 @@
             "content": [
               "Fama, personified as a fast-moving, malicious goddess, the daughter of Terra. From the Greek φήμη, Pheme. Typically translated from the Latin as “Rumor.”"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Proto-Italic *fāmā, from Proto-Indo-European *bʰéh₂meh₂, from *bʰeh₂- (“to speak”). Cognate to Ancient Greek φήμη (phḗmē, “talk”)."
+            }
           }
         ]
       }
@@ -292,6 +305,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Proto-Italic *legō, from Proto-Indo-European *leǵ-. Cognates include Ancient Greek λέγω (légō, “I speak, I choose, I mean”) and Albanian mbledh. May be related to lēx."
+            }
           }
         ]
       }
@@ -314,6 +340,19 @@
             "content": [
               "to teach, profess"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Proto-Italic *legō, from Proto-Indo-European *leǵ-. Cognates include Ancient Greek λέγω (légō, “I speak, I choose, I mean”) and Albanian mbledh. May be related to lēx."
+            }
           }
         ]
       }
@@ -336,6 +375,19 @@
             "content": [
               "a lily"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Ancient Greek λείριον (leírion), from Fayyumic Coptic ϩⲗⲏⲣⲓ (hlēri), from Demotic (ḥrry), from Egyptian D2:D21-D21:X1-M2 (ḥrrt, “flower”).\nPerhaps also the root of Sanskrit हली (halī), हलिनी (halinī, “lily”)."
+            }
           }
         ]
       }
@@ -408,6 +460,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 From Proto-Italic *ū̆skʷe, from Proto-Indo-European *úds-kʷe, from *úd-s (“out, outward”, genitive) + *-kʷe (“and”). Cognate with Sanskrit उच्चा (uccā́), Younger Avestan 𐬎𐬯𐬗𐬀 (usca, “up, out”), Russian вы- (vy-, “out from”), Proto-Germanic *ūt, English out."
+            }
           }
         ]
       }
@@ -508,6 +573,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Perfect passive participle of regō (“to keep or lead straight, to guide”). Corresponds to Proto-Indo-European *h₃reǵtós (“having moved in a straight line”), from Proto-Indo-European *h₃reǵ- (“to straighten, direct”)."
+            }
           }
         ]
       }
@@ -658,6 +736,19 @@
                 ]
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 For Proto-Italic *domos, from Proto-Indo-European *dṓm (“house, home”), from root *dem- (“to build”). Cognates include Ancient Greek δόμος (dómos), Albanian dhomë (“a chamber, a room”), Avestan 𐬛𐬀𐬨- (dam-) Sanskrit दम (dáma), Proto-Slavic *domъ and further to English timber. At least indirectly cognate to Latin dominus.\nThe feminine gender is probably due to the original root noun; attempts to transfer it to the 4th declension are due to 2nd declension feminines being unusual outside of tree names. Some manuscripts of Plautus show forms in dem-; De Vaan (2008) doubts their authenticity."
+            }
           }
         ]
       }
@@ -775,6 +866,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 For Proto-Italic *domos, from Proto-Indo-European *dṓm (“house, home”), from root *dem- (“to build”). Cognates include Ancient Greek δόμος (dómos), Albanian dhomë (“a chamber, a room”), Avestan 𐬛𐬀𐬨- (dam-) Sanskrit दम (dáma), Proto-Slavic *domъ and further to English timber. At least indirectly cognate to Latin dominus.\nThe feminine gender is probably due to the original root noun; attempts to transfer it to the 4th declension are due to 2nd declension feminines being unusual outside of tree names. Some manuscripts of Plautus show forms in dem-; De Vaan (2008) doubts their authenticity."
+            }
           }
         ]
       }

--- a/data/test/dict/ru/en/term_bank_1.json
+++ b/data/test/dict/ru/en/term_bank_1.json
@@ -70,6 +70,19 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Proto-Slavic *sněgъ, from Proto-Balto-Slavic *snáigas, from Proto-Indo-European *snóygʷʰos."
+            }
           }
         ]
       }
@@ -92,6 +105,19 @@
             "content": [
               "snow, the white electrical noise on a TV set when there is no TV signal"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Proto-Slavic *sněgъ, from Proto-Balto-Slavic *snáigas, from Proto-Indo-European *snóygʷʰos."
+            }
           }
         ]
       }
@@ -114,6 +140,19 @@
             "content": [
               "cocaine"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Inherited from Proto-Slavic *sněgъ, from Proto-Balto-Slavic *snáigas, from Proto-Indo-European *snóygʷʰos."
+            }
           }
         ]
       }
@@ -136,6 +175,34 @@
             "content": [
               "to turn white, (intransitive) to whiten"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": [
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "📝 "
+                },
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "по- (po-) + беле́ть (belétʹ)"
+                }
+              ]
+            }
           }
         ]
       }
@@ -169,6 +236,34 @@
             "content": [
               "to become brighter"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": [
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "📝 "
+                },
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "по- (po-) + беле́ть (belétʹ)"
+                }
+              ]
+            }
           }
         ]
       }
@@ -191,6 +286,34 @@
             "content": [
               "to dawn"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": [
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "📝 "
+                },
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "по- (po-) + беле́ть (belétʹ)"
+                }
+              ]
+            }
           }
         ]
       }
@@ -241,6 +364,48 @@
                 }
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": [
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "📝 "
+                },
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "normal-text"
+                  },
+                  "content": "Inherited from Proto-Slavic *zimьnъ. By surface analysis, "
+                },
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "зима́ (zimá) + -ний (-nij)"
+                },
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "normal-text"
+                  },
+                  "content": "."
+                }
+              ]
+            }
           }
         ]
       }
@@ -263,6 +428,48 @@
             "content": [
               "wintry, hibernal"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": [
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "📝 "
+                },
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "normal-text"
+                  },
+                  "content": "Inherited from Proto-Slavic *zimьnъ. By surface analysis, "
+                },
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "target-text"
+                  },
+                  "content": "зима́ (zimá) + -ний (-nij)"
+                },
+                {
+                  "tag": "span",
+                  "data": {
+                    "content": "normal-text"
+                  },
+                  "content": "."
+                }
+              ]
+            }
           }
         ]
       }

--- a/data/test/dict/sq/en/term_bank_1.json
+++ b/data/test/dict/sq/en/term_bank_1.json
@@ -14,6 +14,19 @@
             "content": [
               "ice"
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Uncertain. Possibly:\n# A derivation from Proto-Indo-European *keHl- whence also Proto-Celtic *kaletos (“hard”), Proto-Slavic *kaliti (“to temper, harden”), Latin callum (“hardened skin”).\n# Borrowed from Germanic, ultimately from Proto-Germanic *jekulaz (“icicle”).\n# Akin Old Armenian ոյծ (oyc, “cold, frost”), suffixed with -ull, though the two terms are phonologically incompatible."
+            }
           }
         ]
       }
@@ -351,6 +364,19 @@
                 ]
               }
             ]
+          },
+          {
+            "tag": "div",
+            "data": {
+              "content": "extra-info"
+            },
+            "content": {
+              "tag": "div",
+              "data": {
+                "content": "etymology-entry"
+              },
+              "content": "📝 Unclear. Akin to Arbëresh glunzë (“voice”). Possibilities include:\n# Inherited from Proto-Indo-European *gol(H)-s-os, via a byform *gl̥(H)-s-ós, whence also Proto-Slavic *golsъ (“voice”), Lithuanian gal̃sas (“voice”), Proto-Germanic *kalz-ōną (“to call”). However the medial -h- instead of expected **-sh- is left unexplained.\n# From a byform *ǵʰnud-sḱ-eh₂, doubly methasised from Proto-Indo-European *dn̥ǵʰwéh₂s ~ *dn̥ǵʰuh₂és (“tongue”). Compare Tocharian B kantwo, also metathised. The outcome gl- (and later gj-) from original *ǵ(ʰ)n- is also attested in gju (“knee”). The usage of the infixed *-sḱ- does not seem have any parallels.\n# A connection with Ancient Greek γλῶσσα (glôssa), itself of unclear origin, cannot be proven."
+            }
           }
         ]
       }

--- a/data/test/tidy/cs-en-lemmas.json
+++ b/data/test/tidy/cs-en-lemmas.json
@@ -67,7 +67,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Deverbal from zpravit."
         }
       }
     }
@@ -107,7 +108,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Inherited from Old Czech pro, from Proto-Slavic *pro."
         }
       }
     }
@@ -146,7 +148,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Inherited from Old Czech přieti, from Proto-Slavic *pьrěti."
         }
       }
     }

--- a/data/test/tidy/de-de-lemmas.json
+++ b/data/test/tidy/de-de-lemmas.json
@@ -40,7 +40,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "von arabisch/persisch ruh, roh entlehnt, = arabisch: الرُخّ (ar-ruchch, aus dem Persischen)"
         },
         "1": {
           "ipa": [
@@ -203,7 +204,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "seit dem 20. Jahrhundert bezeugte Entlehnung aus gleichbedeutendem französisch garage ^(→ fr) m, eigentlich „(das) Ausweichen, Ausweichstelle“; dieses ist eine deverbative Ableitung von französisch garer ^(→ fr) „in eine sichere Verwahrstelle bringen; in Sicherheit bringen; ausweichen“, das seinerseits aus okzitanisch garar ^(→ oc) „Acht geben, bewahren“ übernommen wurde; dieses entstammt entweder mit Übergang von w- zu g- der (nicht belegbaren, aber rekonstruierten) germanischen Form *war-ō- „beachten“ (vergleiche »wahren«) oder dem lateinischen varāre ^(→ la) „ausweichen“ (zu lateinisch vārus ^(→ la) „auseinandergebogen“)"
         }
       }
     }

--- a/data/test/tidy/de-en-lemmas.json
+++ b/data/test/tidy/de-en-lemmas.json
@@ -213,7 +213,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "From Middle High German phlëgen, from Old High German plëgan, from Proto-West Germanic *plehan."
         }
       }
     }
@@ -447,7 +448,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "From Middle High German vuhs, from Old High German fuhs, from Proto-West Germanic *fuhs, from Proto-Germanic *fuhsaz, from Proto-Indo-European *púḱsos (“the tailed one”), from *puḱ- (“tail”). Cognate with English fox, Sanskrit पुच्छ (púccha)."
         }
       }
     }
@@ -534,7 +536,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "From Middle High German herze, from Old High German herza, from Proto-West Germanic *hertā, from Proto-Germanic *hertô (“heart”), from Proto-Indo-European *ḱḗr (“heart”).\nCognate with Dutch hart, English heart, Danish hjerte, Gothic 𐌷𐌰𐌹𐍂𐍄𐍉 (hairtō)."
         }
       }
     }
@@ -574,7 +577,9 @@
                 }
               ]
             ]
-          }
+          },
+          "breakdown_text": "fahren (“to drive”) + -er",
+          "etymology_text": "fahren (“to drive”) + -er"
         }
       }
     }
@@ -714,7 +719,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "From Middle High German von (“from”), from Old High German fon, fona (“from”), from Proto-Germanic *afanē, *fanē, *funē (“from”), compound of *afa (from Proto-Indo-European *h₂epó (“from, off”)) + *ana (from Proto-Indo-European *h₂en- (“on”)). Cognate with Old Saxon fana, fan (“from”), Dutch van (“from; of”), Old Frisian fon (“from”)."
         }
       }
     }
@@ -771,7 +777,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "From Middle High German base, from Old High German basa, from Proto-Germanic *baswǭ (“father's sister; paternal aunt”). Compare Saterland Frisian Bääsje (“grandmother”), Dutch baas (“master; boss”). More at boss."
         },
         "2": {
           "ipa": [
@@ -802,7 +809,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "19th c., backformation from Basen, plural of Basis, from Latin basis, from Ancient Greek βάσις (básis)."
         }
       }
     }

--- a/data/test/tidy/en-en-lemmas.json
+++ b/data/test/tidy/en-en-lemmas.json
@@ -160,7 +160,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "From Middle English bryngen, from Old English bringan, from Proto-West Germanic *bringan, from Proto-Germanic *bringaną (“to bring”), from Proto-Indo-European *bʰrenk-, possibly based on *bʰer-.\nCompare West Frisian bringe, Low German bringen, Dutch brengen, German bringen; also Welsh hebrwng (“to bring, lead”), Tocharian B pränk- (“to take away; restrain oneself, hold back”), Latvian brankti (“lying close”), Lithuanian branktas (“whiffletree”)."
         }
       }
     }
@@ -203,7 +204,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "From Middle English wayn, from Old English wæġn, from Proto-West Germanic *wagn, from Proto-Germanic *wagnaz, from Proto-Indo-European *woǵʰnos, from *weǵʰ- (“to bring, transport”). Doublet of wagon, borrowed from Middle Dutch.\nCognates\nCognate with West Frisian wein, Dutch wagen, German Wagen, Danish vogn, Norwegian vogn, Swedish vagn. Doublet of wagon, a borrowing from Dutch."
         }
       }
     }
@@ -306,7 +308,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "From Middle English faucoun, falcon, faulcon, from Old French falcun, from Late Latin falcō (“falcon”), of Germanic origin, probably via Frankish *falkō (“falcon, hawk”), from Proto-Germanic *falkô (“falcon”), from Proto-Indo-European *pol̑- (“pale”), from *pel- (“fallow”).\ncognates\nCognate with Old English *fealca, fealcen (“falcon”), Dutch valk (“falcon, hawk”), German Falke (“falcon, hawk”), Norwegian and Swedish falk (“falcon”), Icelandic fálki (“falcon”), French faucon (“falcon”), Italian falco (“falcon”), Spanish halcón (“falcon”), Portuguese falcão (“falcon”), Latin falco (“falcon”), Lithuanian pálšas (“pale”), Latvian bāls (“pale”), Latgalian buolgs (“pale”). More at fallow."
         }
       }
     }

--- a/data/test/tidy/en-es-lemmas.json
+++ b/data/test/tidy/en-es-lemmas.json
@@ -88,7 +88,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Del inglés medio fast, del inglés antiguo fæst."
         }
       }
     }

--- a/data/test/tidy/es-en-lemmas.json
+++ b/data/test/tidy/es-en-lemmas.json
@@ -103,7 +103,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Inherited from Old Spanish bivir, viver, vevir, bevir, from Latin vīvere. Compare Ladino bivir, Portuguese viver."
         }
       }
     }

--- a/data/test/tidy/fa-en-lemmas.json
+++ b/data/test/tidy/fa-en-lemmas.json
@@ -51,7 +51,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "table\nBorrowed from Hindustani مونگ / मूँग (mūṅg)"
         }
       }
     }
@@ -158,7 +159,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "From Arabic فَارِسِيّ (fārisiyy), from Early New Persian پَارْسِی (pārsī, “Persian, Persic”)."
         }
       }
     }

--- a/data/test/tidy/fr-en-lemmas.json
+++ b/data/test/tidy/fr-en-lemmas.json
@@ -327,7 +327,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Inherited from Middle French prendre, from Old French prendre, prandre, from Latin prēndere, alternative form of prehendere (“to seize”), present active infinitive of prehendō, from prae- (“before”) + *hendō (“to take, seize”) (not attested without prefix), from Proto-Indo-European *gʰed-."
         }
       }
     }
@@ -383,7 +384,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Inherited from Middle French sembler, from Old French sembler, from Late Latin similāre, a verb based on Latin similis (“similar”). Doublet of simuler."
         }
       }
     }
@@ -464,7 +466,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Inherited from Old French chambre, cambre, from Latin cambra, Medieval spelling of Latin camera (“room”), from Ancient Greek καμάρα (kamára, “something with an arched cover: a covered wagon, a covered boat, a vaulted chamber”). Doublet of caméra, a borrowing."
         }
       }
     }
@@ -508,7 +511,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Compare Portuguese de acordo."
         }
       }
     }

--- a/data/test/tidy/ja-en-lemmas.json
+++ b/data/test/tidy/ja-en-lemmas.json
@@ -29,7 +29,9 @@
                 }
               ]
             ]
-          }
+          },
+          "breakdown_text": "A compound of 手 (ta, “hand”, combining form) + 伸す (nosu, “to extend”)",
+          "etymology_text": "⟨tano₁siki₁⟩ → */tanʷosikʲi/ → /tanoshii/\nFrom Old Japanese. First attested in the Kojiki of 712 CE. No Ryukyuan cognates exist; as as result, further derivation unknown. Theories include:\n* A compound of 手 (ta, “hand”, combining form) + 伸す (nosu, “to extend”)\n*: This is problematic, as nosu has first been attested starting from the early 900s, with no A/B distinction (see Jōdai Tokushu Kanazukai for details).\n* From 田神 (tano, literally “rice paddy god”)\n*: No reading of 神 (*no, “god”) exists.\n* A borrowing from an unknown language\n*: No words resemble *tanV meaning \"fun\" or \"to enjoy\"."
         }
       }
     }
@@ -81,7 +83,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "The 連(れん)用(よう)形(けい) (ren'yōkei, “stem or continuative form”) of the verb 好(す)く (suku, “to like, to be fond of, to enjoy, to feel love for”).\nFirst cited to the late 900s in the 宇津保物語 (Utsubo Monogatari)."
         }
       }
     }
@@ -209,7 +212,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "According to one theory, derived from 手貫 (tanuki, “arm glove, gauntlet”), which raccoon dog hide was sometimes used for."
         }
       }
     }
@@ -644,7 +648,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "The perfective form of お腹が空く (onaka ga suku, “to become hungry”, literally “one's stomach becomes empty”)."
         }
       }
     }

--- a/data/test/tidy/ko-en-lemmas.json
+++ b/data/test/tidy/ko-en-lemmas.json
@@ -34,7 +34,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Sino-Korean word from 獨逸, an orthographic borrowing from Japanese 獨逸 (Doitsu, “Germany”), from Dutch Duits (“German”)."
         }
       }
     }

--- a/data/test/tidy/la-en-lemmas.json
+++ b/data/test/tidy/la-en-lemmas.json
@@ -122,7 +122,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "From Proto-Italic *fāmā, from Proto-Indo-European *bʰéh₂meh₂, from *bʰeh₂- (“to speak”). Cognate to Ancient Greek φήμη (phḗmē, “talk”)."
         }
       }
     }
@@ -297,7 +298,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "From Proto-Italic *legō, from Proto-Indo-European *leǵ-. Cognates include Ancient Greek λέγω (légō, “I speak, I choose, I mean”) and Albanian mbledh. May be related to lēx."
         }
       }
     }
@@ -355,7 +357,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "From Ancient Greek λείριον (leírion), from Fayyumic Coptic ϩⲗⲏⲣⲓ (hlēri), from Demotic (ḥrry), from Egyptian D2:D21-D21:X1-M2 (ḥrrt, “flower”).\nPerhaps also the root of Sanskrit हली (halī), हलिनी (halinī, “lily”)."
         }
       }
     }
@@ -465,7 +468,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "From Proto-Italic *ū̆skʷe, from Proto-Indo-European *úds-kʷe, from *úd-s (“out, outward”, genitive) + *-kʷe (“and”). Cognate with Sanskrit उच्चा (uccā́), Younger Avestan 𐬎𐬯𐬗𐬀 (usca, “up, out”), Russian вы- (vy-, “out from”), Proto-Germanic *ūt, English out."
         }
       }
     }
@@ -585,7 +589,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Perfect passive participle of regō (“to keep or lead straight, to guide”). Corresponds to Proto-Indo-European *h₃reǵtós (“having moved in a straight line”), from Proto-Indo-European *h₃reǵ- (“to straighten, direct”)."
         }
       }
     }
@@ -815,7 +820,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "For Proto-Italic *domos, from Proto-Indo-European *dṓm (“house, home”), from root *dem- (“to build”). Cognates include Ancient Greek δόμος (dómos), Albanian dhomë (“a chamber, a room”), Avestan 𐬛𐬀𐬨- (dam-) Sanskrit दम (dáma), Proto-Slavic *domъ and further to English timber. At least indirectly cognate to Latin dominus.\nThe feminine gender is probably due to the original root noun; attempts to transfer it to the 4th declension are due to 2nd declension feminines being unusual outside of tree names. Some manuscripts of Plautus show forms in dem-; De Vaan (2008) doubts their authenticity."
         }
       }
     }

--- a/data/test/tidy/ru-en-lemmas.json
+++ b/data/test/tidy/ru-en-lemmas.json
@@ -81,7 +81,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Inherited from Proto-Slavic *sněgъ, from Proto-Balto-Slavic *snáigas, from Proto-Indo-European *snóygʷʰos."
         }
       }
     }
@@ -176,7 +177,9 @@
                 }
               ]
             ]
-          }
+          },
+          "breakdown_text": "по- (po-) + беле́ть (belétʹ)",
+          "etymology_text": "по- (po-) + беле́ть (belétʹ)"
         }
       }
     }
@@ -234,7 +237,9 @@
                 }
               ]
             ]
-          }
+          },
+          "breakdown_text": "зима́ (zimá) + -ний (-nij)",
+          "etymology_text": "Inherited from Proto-Slavic *zimьnъ. By surface analysis, зима́ (zimá) + -ний (-nij)."
         }
       }
     }

--- a/data/test/tidy/sq-en-lemmas.json
+++ b/data/test/tidy/sq-en-lemmas.json
@@ -31,7 +31,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Uncertain. Possibly:\n# A derivation from Proto-Indo-European *keHl- whence also Proto-Celtic *kaletos (“hard”), Proto-Slavic *kaliti (“to temper, harden”), Latin callum (“hardened skin”).\n# Borrowed from Germanic, ultimately from Proto-Germanic *jekulaz (“icicle”).\n# Akin Old Armenian ոյծ (oyc, “cold, frost”), suffixed with -ull, though the two terms are phonologically incompatible."
         }
       }
     }
@@ -244,7 +245,8 @@
                 }
               ]
             ]
-          }
+          },
+          "etymology_text": "Unclear. Akin to Arbëresh glunzë (“voice”). Possibilities include:\n# Inherited from Proto-Indo-European *gol(H)-s-os, via a byform *gl̥(H)-s-ós, whence also Proto-Slavic *golsъ (“voice”), Lithuanian gal̃sas (“voice”), Proto-Germanic *kalz-ōną (“to call”). However the medial -h- instead of expected **-sh- is left unexplained.\n# From a byform *ǵʰnud-sḱ-eh₂, doubly methasised from Proto-Indo-European *dn̥ǵʰwéh₂s ~ *dn̥ǵʰuh₂és (“tongue”). Compare Tocharian B kantwo, also metathised. The outcome gl- (and later gj-) from original *ǵ(ʰ)n- is also attested in gju (“knee”). The usage of the infixed *-sḱ- does not seem have any parallels.\n# A connection with Ancient Greek γλῶσσα (glôssa), itself of unclear origin, cannot be proven."
         }
       }
     }

--- a/types.ts
+++ b/types.ts
@@ -17,6 +17,7 @@ declare global {
         word?: string;
         pos?: string;
         etymology_number?: number;
+        etymology_text?: string;
         sounds?: Sound[];  
         forms?: FormInfo[];
         senses?: KaikkiSense[];
@@ -98,6 +99,8 @@ declare global {
     type LemmaInfo = {
         ipa: IpaInfo[],
         glossTree: GlossTree,
+        etymology_text?: string,
+        breakdown_text?: string,
     }
 
     type IpaInfo = {


### PR DESCRIPTION
Adds hidden-by-default etymology entries to each relevant definition.

#### 3-tidy-up.js

The keys `etymology_text` and `breakdown_text` are written to each `lemmaDict` entry where etymology is provided in the `parsedLine`.

The `breakdown_text` is a shortened version of the `etymology_text` where only the break down part is saved:

`Borrowed from Old Church Slavonic въплътити (vŭplŭtiti). By surface analysis, во- (vo-) +‎ плоть (plotʹ) +‎ -и́ть (-ítʹ). ` becomes `во- (vo-) +‎ плоть (plotʹ) +‎ -и́ть (-ítʹ)`. This extra key is handled later in `4-make-yomitan.js`.

I should also mention that I added this during the lemma and form JSON creation part:

```js
for (const file of readdirSync(writeFolder)) {
    if (file.includes(`${sourceIso}-${targetIso}`)) {
        unlinkSync(`${writeFolder}/${file}`);
    }
}
```
I noticed while testing with a small pool of words that some leftover data was still in the `writeFolder` from a previous run, and that data was being added to my smaller dictionary. That loop should prevent that.

#### 4-make-yomitan.js

The function `getStructuredEtym` creates an `extra-info` element similar to how example sentences are structured. In order for me to only see `breakdown_text` in the etymology entry, I create multiple span elements for the element's content rather than just a text node, and I add CSS in Yomitan settings to filter out only the spans I want to see.

The content is handled like this:

```html
Borrowed from Old Church Slavonic въплътити (vŭplŭtiti). By surface analysis, во- (vo-) +‎ плоть (plotʹ) +‎ -и́ть (-ítʹ). 
```

```html
<span class="gloss-sc-span" data-sc-content="target-text">📝 </span>
<span class="gloss-sc-span" data-sc-content="normal-text">Borrowed from Old Church Slavonic въплътити (vŭplŭtiti). By surface analysis, </span>
<span class="gloss-sc-span" data-sc-content="target-text">во- (vo-) + плоть (plotʹ) + -и́ть (-ítʹ)</span>
<span class="gloss-sc-span" data-sc-content="normal-text">.</span>
```
If the entry has no `breakdown_text`, the etymology is added as a text node like usual.

#### data\styles.css

The CSS for etymology entries are very similar to example sentence entries. The etymology entries are hidden by default.

A user can show these entries by adding this to Yomitan's custom CSS setting:

```css
div[data-sc-content="etymology-entry"] {
  display: block;
}
```

If the user wants to only see break down text like myself, they can instead add:

```css
div[data-sc-content="etymology-entry"]:has(span[data-sc-content="target-text"]) {
  display: block;
}

span[data-sc-content="normal-text"] {
  display: none;
}
```