### PR TITLE
Check that `DICT_NAME` actually exists

### DIFF
--- a/auto.sh
+++ b/auto.sh
@@ -100,6 +100,10 @@ export DEBUG_WORD
 export DICT_NAME
 max_memory_mb=${MAX_MEMORY_MB:-8192}
 
+if [[ -z "$DICT_NAME" ]]; then
+  echo "Error: DICT_NAME is empty or not set"
+  exit 1
+fi
 
 # Check for the source_language and target_language arguments
 if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then


### PR DESCRIPTION
I was moving things around and had everything (dumps, latest version etc.) ...but the `.env`. A reasonable mistake. Or probably not so reasonable since it's the first thing stated in the README.

Now, the error I got was not very telling. Everything went well... until the zipping part. 

```
zip error: Invalid command arguments (option 'l' (convert text file line ends - LF->CRLF) not negatable)
```

Since I had no `.env`, `DICT_NAME` was undefined, and here:

```bash
  dict_title="${DICT_NAME}-$source_iso-$target_iso-gloss"
  ...
  zip -qj "$dict_file" $temp_folder/dict/index.json ...
```

`dict_title` ends up being `-el-el`, so the command takes it as a flag...

Maybe checking for `DICT_NAME` would be wiser, but at any rate, this should probably be enough to prevent dumb people like me from doing dumb things :D
